### PR TITLE
Support surgical linker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,16 @@ generated-docs/
 
 build
 app
+dynhost
 
 *.a
 *.tar.br
 *.tar.gz
 *.ll
+*.so
+*.h
+*.rh
+*.rm
 
 host/libhost.h
 

--- a/host/main-for-legacy.go
+++ b/host/main-for-legacy.go
@@ -1,0 +1,11 @@
+//go:build legacy
+
+package main
+
+//#cgo CFLAGS: -Wno-main-return-type
+import "C"
+
+//export main
+func main() {
+	entry()
+}

--- a/host/main-for-surgical.go
+++ b/host/main-for-surgical.go
@@ -1,0 +1,7 @@
+//go:build !legacy
+
+package main
+
+func main() {
+	entry()
+}

--- a/host/main.go
+++ b/host/main.go
@@ -1,8 +1,5 @@
 package main
 
-//#cgo CFLAGS: -Wno-main-return-type
-import "C"
-
 import (
 	"fmt"
 
@@ -10,8 +7,7 @@ import (
 	"host/roc_app"
 )
 
-//export main
-func main() {
+func entry() {
 	var foo = roc_app.Main()
 
 	fmt.Print(foo)

--- a/roc_app_templates/main.go
+++ b/roc_app_templates/main.go
@@ -1,13 +1,16 @@
 package roc_app
 
-//#include "main.h"
+/*
+#cgo LDFLAGS: -L.. -lapp
+#include "./main.h"
+*/
 import "C"
 
 import (
-	"os"
 	"fmt"
-	"unsafe"
 	"host/roc_std"
+	"os"
+	"unsafe"
 )
 
 func Main() roc_std.RocStr {


### PR DESCRIPTION
Working with the template on linux would be much nicer, if the surgical linker was supported.

I was able, to support both linkers in the [kingfisher build.roc](https://github.com/ostcar/kingfisher/blob/main/build.roc)

I tried to do the same here, but it does not work. `roc build.roc` crashes with
```
thread 'main' panicked at crates/compiler/gen_llvm/src/llvm/build.rs:5764:19:
Error in alias analysis: error in module ModName("UserApp"), function definition FuncName("$\x00\x00\x00/\x00\x00\x00\xd7\xdf+\xc0\xac\x92\\\xfc"), definition of value binding ValueId(4): expected type '(union { (union { ((),), ((heap_cell,),), () },), ((),), ((heap_cell,),), () },)', found type '(union { ((),), ((heap_cell,),), () },)'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I don't know, that that means or how to fix it. I think, it has something to do with the error accumulation.

Could you help me writing this file?

It would be really nice, if the build script would support arguments to build for the local target or for all targets. So you have a fast feedback for local development, but you can build for a release. 