### PR TITLE
Fix SPDX attestation predicate verification

### DIFF
--- a/scripts/fetch_runtime.py
+++ b/scripts/fetch_runtime.py
@@ -17,7 +17,7 @@ from runtime_assets import (ROOT, REPO, WORKFLOW, MANIFEST, RUNTIME_PATHS, PAYLO
 
 LOCK = ROOT / "scripts/runtime_release.json"
 PROVENANCE = "https://slsa.dev/provenance/v1"
-SBOM_TYPE = "https://spdx.dev/Document"
+SBOM_TYPE = "https://spdx.dev/Document/v2.3"
 
 
 def load_lock(path: Path = LOCK) -> dict:

--- a/scripts/test_runtime.py
+++ b/scripts/test_runtime.py
@@ -92,7 +92,14 @@ class RuntimeTests(unittest.TestCase):
     def test_release_verification_requires_both_predicates_and_matching_sbom(self):
         document = json.loads((self.archive.parent / 'runtime.spdx.json').read_text())
         verified = [{'verificationResult': {'statement': {'predicate': document}}}]
-        with patch.object(fetch, 'verify_attestation', return_value=verified) as verify:
+        # The pinned signing action derives the predicate URI from spdxVersion.
+        def producer_verification(artifact, bundle, lock, predicate):
+            supported = {fetch.PROVENANCE, 'https://spdx.dev/Document/v' + document['spdxVersion'].split('-')[1]}
+            if predicate not in supported:
+                raise ValueError('No attestation with the requested predicate')
+            return verified
+
+        with patch.object(fetch, 'verify_attestation', side_effect=producer_verification) as verify:
             self.assertEqual(fetch.verify_release(self.archive.parent, self.lock), self.archive)
             self.assertEqual([c.args[3] for c in verify.call_args_list], [fetch.PROVENANCE, fetch.PROVENANCE, fetch.SBOM_TYPE])
         with patch.object(fetch, 'verify_attestation', return_value=[{'verificationResult': {'statement': {'predicate': {}}}}]):


### PR DESCRIPTION
The pinned attestation action emits the SPDX 2.3 predicate as `https://spdx.dev/Document/v2.3`. Runtime verification requested the unversioned URI, which would reject the signed SBOM before publication. Use the producer’s versioned URI.

Validation: added a regression test that derives the URI independently from the SBOM version; it fails before this fix and all 13 tooling tests pass afterward. Full required CI runs before merge.
